### PR TITLE
Add handling for PENDING_CHARGE state

### DIFF
--- a/batime@martin.zurowietz.de/power.js
+++ b/batime@martin.zurowietz.de/power.js
@@ -14,8 +14,10 @@ var Indicator = GObject.registerClass(
          seconds = this._proxy.TimeToFull;
       } else if (this._proxy.State === UPower.DeviceState.DISCHARGING) {
          seconds = this._proxy.TimeToEmpty;
+      } else if (this._proxy.State === UPower.DeviceState.PENDING_CHARGE) {
+         return '';
       } else {
-         // state is one of PENDING_CHARGING, PENDING_DISCHARGING
+         // state is PENDING_DISCHARGE or UNKNOWN
          return _('Estimating…');
       }
 


### PR DESCRIPTION
Based on testing the state is reached when
the hardware's charge limit blocks further
charging.

GNOME displays the state as "Not Charging"
in the power options and the quick settings.
The used icon is the default, non-charging
battery.

Currently batime shows PENDING_CHARGE as
"Estimating..." which suggests a temporary
state. Without external change
the state is permanent (based on my testing).

As I see it there are two options for batime:
- Handle the case the same as Full Charged (Empty String)
- Introduce a new special state ("Not charging", "Charging limit", ...)

The first option makes the most sense in my opinion as the
hardware is currently not charging, nor discharging. The icon
signals that the battery is not 100% loaded.

This PR implements the first option.

Empty string:
![image](https://user-images.githubusercontent.com/520251/155179848-8563e7da-a63a-4613-9666-5cade8ff53cf.png)

Special state:
![image](https://user-images.githubusercontent.com/520251/155179464-41c17380-5c59-4b63-96a9-194e89abfad2.png)
