### PR TITLE
Add support for GNOME 42

### DIFF
--- a/batime@martin.zurowietz.de/metadata.json
+++ b/batime@martin.zurowietz.de/metadata.json
@@ -2,7 +2,8 @@
 {
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "uuid": "batime@martin.zurowietz.de",
   "url": "https://github.com/mzur/gnome-shell-batime",


### PR DESCRIPTION
Tested for an hour on Fedora 36. No regressions/warnings/errors found. Seems to just work.