### PR TITLE
Add support for Gnome 49

### DIFF
--- a/batime@martin.zurowietz.de/metadata.json
+++ b/batime@martin.zurowietz.de/metadata.json
@@ -4,7 +4,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "uuid": "batime@martin.zurowietz.de",
   "url": "https://github.com/mzur/gnome-shell-batime",


### PR DESCRIPTION
Tested this on two Fedora 43 (Gnome 49, Wayland) systems.
No regressions found. No warnings or errors in `journalctl /usr/bin/gnome-shell -b`.