### PR TITLE
fix: handle PENDING_CHARGE state for time-to-full on GNOME 50+

### DIFF
--- a/batime@martin.zurowietz.de/extension.js
+++ b/batime@martin.zurowietz.de/extension.js
@@ -16,7 +16,8 @@ const _powerToggleSyncOverride = function () {
    let seconds = 0;
    let state = this._proxy.State;
 
-   if (this._proxy.State === UPower.DeviceState.CHARGING) {
+   if (this._proxy.State === UPower.DeviceState.CHARGING ||
+       this._proxy.State === UPower.DeviceState.PENDING_CHARGE) {
       seconds = this._proxy.TimeToFull;
    } else if (this._proxy.State === UPower.DeviceState.DISCHARGING) {
       seconds = this._proxy.TimeToEmpty;


### PR DESCRIPTION
## Problem

On GNOME Shell 50 / Fedora 43+, batteries that are plugged in but not actively charging (e.g. due to charge threshold support) report `PENDING_CHARGE` state instead of `CHARGING`. The extension only checked for `CHARGING`, so time-to-full was never shown in this state.

Discharging time worked fine because `DISCHARGING` was already handled.

## Fix

Added `UPower.DeviceState.PENDING_CHARGE` alongside `CHARGING` in the state check in `_powerToggleSyncOverride`, so `TimeToFull` is used for both states. This matches how GNOME Shell 50's own `PowerToggle._sync()` handles these states.

## Testing

- Verified on GNOME Shell 50.2 / Fedora 44
- Discharge time display: working ✅
- Charge time display: now works when battery reports PENDING_CHARGE ✅